### PR TITLE
added taggability to users, kids and articles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'autoprefixer-rails', '10.2.5'
 gem 'font-awesome-sass'
 gem 'simple_form'
 gem 'ibm_watson'
+gem 'acts-as-taggable-on', '~> 9.0'
+
 group :development, :test do  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts-as-taggable-on (9.0.1)
+      activerecord (>= 6.0, < 7.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.2.5.0)
@@ -280,6 +282,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 9.0)
   autoprefixer-rails (= 10.2.5)
   bootsnap (>= 1.4.4)
   byebug

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,10 @@
+class UsersController < ApplicationController
+  def user_params
+    params.require(:user).permit(:name, :tag_list) ## Rails 4 strong params usage
+  end
+  # this was the documentation but not sure how it will play with devise
+end
+
+# @user.tag_list.add("awesome")   # add a single tag. alias for <<
+# @user.tag_list.remove("awesome") # remove a single tag
+# @user.save # save to persist tag_list

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
+  acts_as_taggable_on :tags
   validates :title, :date, :author, :content, :image, presence: true
 end

--- a/app/models/kid.rb
+++ b/app/models/kid.rb
@@ -1,4 +1,5 @@
 class Kid < ApplicationRecord
+  acts_as_taggable_on :tags
   belongs_to :user
   belongs_to :dictionary
   has_many :statistics

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  acts_as_taggable_on :tags
   has_many :kids, dependent: :destroy
   has_many :dictionaries, through: :kids, dependent: :destroy
   # Include default devise modules. Others available are:

--- a/db/migrate/20220215041200_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220215041200_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20220215041201_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220215041201_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20220215041202_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220215041202_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20220215041203_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220215041203_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20220215041204_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220215041204_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20220215041205_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220215041205_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20220215041206_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220215041206_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_10_120649) do
+ActiveRecord::Schema.define(version: 2022_02_15_041206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,10 +47,56 @@ ActiveRecord::Schema.define(version: 2022_02_10_120649) do
     t.index ["user_id"], name: "index_kids_on_user_id"
   end
 
+  create_table "statistics", force: :cascade do |t|
+    t.integer "total_tweets"
+    t.integer "angry_tweets"
+    t.integer "sad_tweets"
+    t.integer "fearful_tweets"
+    t.integer "joyful_tweets"
+    t.integer "analytical_tweets"
+    t.integer "confident_tweets"
+    t.integer "tentative_tweets"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "kid_id"
+    t.index ["kid_id"], name: "index_statistics_on_kid_id"
+  end
+
   create_table "suggestions", force: :cascade do |t|
     t.string "word"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -69,4 +115,5 @@ ActiveRecord::Schema.define(version: 2022_02_10_120649) do
 
   add_foreign_key "kids", "dictionaries"
   add_foreign_key "kids", "users"
+  add_foreign_key "taggings", "tags"
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
added taggability to users, kids and articles - after merging make sure your gemfile has 
gem 'acts-as-taggable-on', '~> 9.0'

then 

bundle
rake acts_as_taggable_on_engine:install:migrations
rails db:migrate