### PR TITLE
made statistics have a tone enum category

### DIFF
--- a/app/models/statistic.rb
+++ b/app/models/statistic.rb
@@ -1,3 +1,6 @@
 class Statistic < ApplicationRecord
   belongs_to :kid
+
+  enum tone: { joy: 0, analytical: 1, tentative: 2,
+                 confident: 3, fear: 4, sad: 5, angry: 6 }
 end

--- a/db/migrate/20220222121915_drop_column_from_statistics.rb
+++ b/db/migrate/20220222121915_drop_column_from_statistics.rb
@@ -1,0 +1,13 @@
+class DropColumnFromStatistics < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :statistics, :total_tweets
+    remove_column :statistics, :angry_tweets
+    remove_column :statistics, :sad_tweets
+    remove_column :statistics, :fearful_tweets
+    remove_column :statistics, :joyful_tweets
+    remove_column :statistics, :analytical_tweets
+    remove_column :statistics, :confident_tweets
+    remove_column :statistics, :tentative_tweets
+    add_column :statistics, :tone, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_16_150812) do
+ActiveRecord::Schema.define(version: 2022_02_22_121915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,17 +48,10 @@ ActiveRecord::Schema.define(version: 2022_02_16_150812) do
   end
 
   create_table "statistics", force: :cascade do |t|
-    t.integer "total_tweets"
-    t.integer "angry_tweets"
-    t.integer "sad_tweets"
-    t.integer "fearful_tweets"
-    t.integer "joyful_tweets"
-    t.integer "analytical_tweets"
-    t.integer "confident_tweets"
-    t.integer "tentative_tweets"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "kid_id"
+    t.integer "tone"
     t.index ["kid_id"], name: "index_statistics_on_kid_id"
   end
 


### PR DESCRIPTION
Added the stats enum as "tone" 
can do the following actions on a Kid instance

kid.statistics
kid.statistics.count
kid.statistics.(tone_name --> for example "confident") 
e.g. kid.statistics.confident # returns all stats with tone of confident
kid.statistics.confident.count # returns number of confident tone tweets 

and so on and so forth 
<img width="569" alt="Screen Shot 2022-02-24 at 9 46 27" src="https://user-images.githubusercontent.com/86721807/155435894-394f5132-c907-45f9-91b6-f0034d0a9ead.png">

