### PR TITLE
set font variables and base font weights

### DIFF
--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -8,6 +8,8 @@ $font-family-sans-serif:  $body-font;
 $headings-font-family:    $headers-font;
 $body-bg:                 $light-gray;
 $font-size-base: 1rem;
+$headings-font-weight: $headers-weight;
+$font-weight-base: $body-weight;
 
 // Colors
 $body-color: $gray;

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,9 +1,11 @@
 // Import Google fonts
-@import url("https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&family=Open+Sans&display=swap');
 
 // Define fonts for body and headers
-$body-font: "Work Sans", "Helvetica", "sans-serif";
-$headers-font: "Nunito", "Helvetica", "sans-serif";
+$body-font: "open sans";
+$headers-font: "montserrat";
+$headers-weight: 500;
+$body-weight: 400;
 
 // To use a font file (.woff) uncomment following lines
 // @font-face {

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -47,7 +47,7 @@
         <p>The Chirpy extension provides you with piece of mind and protection at the click of a button.</p>
         <p>Using technology developed by the brilliant minds at IBM we can automatically remove harmful content without your child ever even having to see it.</p>
         <p>And, if you want to take it a step further you are able to input your own custom list of topics you want to remove from the web in our 'Dictionary' tab.</p>
-        <p>Learn about your kids, use our article system to get up to date with what the kids are going through these days.</p>
+        <p>Learn about your kids, use our library of articles to get up to date with what kids are going through these days.</p>
 
         <div class="banner-btn">
           <p class="text-center pb-1">Download Chirpy today, and make a positive change!</p>


### PR DESCRIPTION
Created font variables and base font weights for the page.

It looks like other fonts and font weights have been set for things like the article cards and shit, so they are overriding these settings. 

We might want to change them.

Also, I have set the headings as montserrat and body as open-sans just as a placeholder.