### PR TITLE
change the link to home instead of dashboard

### DIFF
--- a/chirpy_extension/Chirpy_chrome_extension/popup.html
+++ b/chirpy_extension/Chirpy_chrome_extension/popup.html
@@ -77,7 +77,7 @@
         <h3>Visit Chirpy:</h3>
         <div>
           <button id="go_to_chirpy" class="btn btn-flat">
-            <h3>Dashboard</h3>
+            <h3>Chirpy</h3>
           </button>
         </div>
       </div>

--- a/chirpy_extension/Chirpy_chrome_extension/scripts/popup.js
+++ b/chirpy_extension/Chirpy_chrome_extension/scripts/popup.js
@@ -95,7 +95,7 @@ document
   .addEventListener("click", () => openRequestedPopup());
 
 function openRequestedPopup() {
-  window.open("https://www.chirpyapp.net/dashboards", "_blank");
+  window.open("https://www.chirpyapp.net", "_blank");
 }
 
 // Sign out button


### PR DESCRIPTION
Changed the extension link to home instead of dashboard because if the user isn't signed in on their browser it will put out a 500 error instead of redirecting them to the home page.

![Screenshot 2022-03-23 at 19 46 25](https://user-images.githubusercontent.com/84076465/159683051-0506074a-6969-4fcf-a529-4ae5a095b5b0.png)
